### PR TITLE
Fixed Issue 34

### DIFF
--- a/Configuration.cs
+++ b/Configuration.cs
@@ -178,6 +178,10 @@ namespace KSPAdvancedFlyByWire
         {
             foreach (ControllerConfiguration config in controllers)
             {
+              /// Catch exceptions from any one controller to prevent overwrite 
+              /// of presets for all controllers.
+              try
+              {
                 if (Utility.CheckXInputSupport() && config.wrapper == InputWrapper.XInput)
                 {
 #if !LINUX
@@ -206,7 +210,16 @@ namespace KSPAdvancedFlyByWire
 
                 for (int i = 0; i < config.iface.GetAxesCount(); i++)
                 {
-                    config.iface.axisStates[i] = config.axisConfigurations[i];
+                    /// Protection from flaky SDL behaviour. SDL may report more axis
+                    /// than was previously accounted for in the configuration file.
+                    if (i < config.axisConfigurations.Count)
+                    {
+                        config.iface.axisStates[i] = config.axisConfigurations[i];
+                    }
+                    else
+                    {
+                        config.iface.axisStates[i] = new AxisConfiguration();
+                    }
                 }
 
                 config.axisConfigurations = null;
@@ -217,6 +230,10 @@ namespace KSPAdvancedFlyByWire
                 }
 
                 config.iface.manualDeadZones = config.manualDeadZones;
+              }
+
+              catch { }
+
             }
         }
 


### PR DESCRIPTION
This should fix issue #34. (Config preset overwrite)

The overwrite is caused by an exception in Configuration::OnPostDeserialize(). The exception is then caught and tossed causing AdvancedFlyByWire::LoadState() to see a null config and create an empty one. This empty config will overwrite the old one on the next serialize.

The underlying cause of this problem is the SDL library. Under certain conditions it can create a controller with no axis and no buttons. Then the next time (a new flight) it will create the controller with all the buttons and axis. Another time it might not create any controller at all. When AFBW de-serializes a config that has no axis defined, but there are currently axis defined by SDL, it will generate an out-of-bounds exception. The fix for this is simple but I also added a try/catch around each controller setup to prevent one fail from nuking the whole configuration.

Here is the setup I used to debug and test with. Note that I'm only using the 360 controller here. The X-55 is never detected by SDL under Win8.1. The 360 controller is working fine against the XInput library. The rogue controller discussed above (from SDL) is a mirror of the XInput one except that the axis and buttons and not labeled.


XBox360 Wireless controller.
Saitek X-55 Rhino HOTAS connected with the profiler software installed and running.

KSP: 0.90 (Win32) - Unity: 4.5.5f1 - OS: Windows 8.1  (6.3.9600) 64bit
Ferram Aerospace Research - 0.14.6
RasterPropMonitor - 0.18.3
Kerbal Engineer Redux 1.0 - 1.0.14.1
KineTechAnimation - 1.1.1
Advanced Fly-By-Wire - 1.4.6
KSP-AVC Plugin - 1.1.5
Docking Port Alignment Indicator - 5.1
RemoteTech - 1.6.2
ResGen - 0.28.2
TAC Life Support - 0.10.2.15
