### PR TITLE
Make SAS override optional; trim fixes

### DIFF
--- a/AdvancedFlyByWire.cs
+++ b/AdvancedFlyByWire.cs
@@ -25,6 +25,8 @@ namespace KSPAdvancedFlyByWire
         public bool m_UsePrecisionModeFactor = false;
         public float m_PrecisionModeFactor = 0.5f;
 
+        public bool m_IgnoreFlightCtrlState = true;
+
         // Configuration
         private static readonly string addonFolder = Path.Combine(Path.Combine(KSPUtil.ApplicationRootPath, "GameData"), "ksp-advanced-flybywire");
         private Configuration m_Configuration = null;
@@ -103,6 +105,7 @@ namespace KSPAdvancedFlyByWire
                 m_UseOldPresetsWindow = pluginConfig.GetValue("useOldPresetEditor", false);
                 m_UsePrecisionModeFactor = pluginConfig.GetValue("usePrecisionModeFactor", false);
                 m_PrecisionModeFactor = float.Parse(pluginConfig.GetValue("precisionModeFactor", "0.5"));
+                m_IgnoreFlightCtrlState = pluginConfig.GetValue("ignoreFlightCtrlState", true);
             }
             
             m_Configuration = Configuration.Deserialize(GetAbsoluteConfigurationPath());
@@ -125,6 +128,7 @@ namespace KSPAdvancedFlyByWire
                 pluginConfig["useOldPresetEditor"] = m_UseOldPresetsWindow;
                 pluginConfig["usePrecisionModeFactor"] = m_UsePrecisionModeFactor;
                 pluginConfig["precisionModeFactor"] = m_PrecisionModeFactor.ToString();
+                pluginConfig["ignoreFlightCtrlState"] = m_IgnoreFlightCtrlState;
                 pluginConfig.save();
             }
 

--- a/FlightManager.cs
+++ b/FlightManager.cs
@@ -51,8 +51,7 @@ namespace KSPAdvancedFlyByWire
                 {
                     config.iface.Update(state);
                     UpdateAxes(config, state);
-                    UpdateFlightProperties(config, state);
-
+                    
                     if (FlightGlobals.ActiveVessel.isEVA)
                     {
                         EVAController.Instance.UpdateEVAFlightProperties(config, state);
@@ -65,6 +64,8 @@ namespace KSPAdvancedFlyByWire
                     );
                 }
             }
+
+            UpdateFlightProperties(state);
 
             ZeroOutFlightProperties();
 
@@ -111,7 +112,7 @@ namespace KSPAdvancedFlyByWire
             }
         }
 
-        private void UpdateFlightProperties(ControllerConfiguration config, FlightCtrlState state)
+        private void UpdateFlightProperties(FlightCtrlState state)
         {
             state.yawTrim = m_Yaw.GetTrim();
             state.pitchTrim = m_Pitch.GetTrim();

--- a/FlightManager.cs
+++ b/FlightManager.cs
@@ -114,9 +114,10 @@ namespace KSPAdvancedFlyByWire
 
         private void UpdateFlightProperties(FlightCtrlState state)
         {
-            state.yawTrim = m_Yaw.GetTrim();
+            // As of 0.90, setting these trim values seems to have no effect.
+            /*state.yawTrim = m_Yaw.GetTrim();
             state.pitchTrim = m_Pitch.GetTrim();
-            state.rollTrim = m_Roll.GetTrim();
+            state.rollTrim = m_Roll.GetTrim();*/
 
             float precisionModeFactor = AdvancedFlyByWire.Instance.GetPrecisionModeFactor();
             state.yaw = Utility.Clamp(state.yaw + m_Yaw.Update() * precisionModeFactor, -1.0f, 1.0f);
@@ -366,7 +367,6 @@ namespace KSPAdvancedFlyByWire
                     m_Yaw.SetTrim(0.0f);
                     m_Pitch.SetTrim(0.0f);
                     m_Roll.SetTrim(0.0f);
-                    state.ResetTrim();
                     return;
                 case DiscreteAction.IVANextCamera:
                     CameraController.Instance.NextIVACamera();

--- a/FlightManager.cs
+++ b/FlightManager.cs
@@ -37,8 +37,10 @@ namespace KSPAdvancedFlyByWire
             // State may arrive with SAS or WASD controls pre-applied. Save it and reset pitch/yaw/roll so that it doesn't mess with input.
             FlightCtrlState preState = new FlightCtrlState();
             preState.CopyFrom(state);
-            state.pitch = 0; state.yaw = 0; state.roll = 0;
-
+            if (AdvancedFlyByWire.Instance.m_IgnoreFlightCtrlState)
+            {
+                state.pitch = 0; state.yaw = 0; state.roll = 0;
+            }
             // skill vessel input if we're in time-warp
             m_DisableVesselControls = TimeWarp.fetch != null && TimeWarp.fetch.current_rate_index != 0 && TimeWarp.fetch.Mode == TimeWarp.Modes.HIGH;
 
@@ -69,11 +71,12 @@ namespace KSPAdvancedFlyByWire
 
             ZeroOutFlightProperties();
 
-            // Apply pre-state if not neutral and no AFBW input.
-            if (!preState.isNeutral)
+            // Apply pre-state if not neutral and no AFBW input (including trim).
+            if (!preState.isNeutral && AdvancedFlyByWire.Instance.m_IgnoreFlightCtrlState)
             {
                 float t = controlDetectionThreshold;
                 bool hasInput = Math.Abs(state.pitch) > t || Math.Abs(state.yaw) > t || Math.Abs(state.roll) > t;
+                // hasInput will always be true if trim is active on any axis
                 if (!hasInput)
                 {
                     state.pitch = preState.pitch;

--- a/ModSettingsWindow.cs
+++ b/ModSettingsWindow.cs
@@ -67,6 +67,12 @@ namespace KSPAdvancedFlyByWire
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
+            GUILayout.Label("AFBW input overrides SAS and other control inputs");
+            AdvancedFlyByWire.Instance.m_IgnoreFlightCtrlState = GUILayout.Toggle(AdvancedFlyByWire.Instance.m_IgnoreFlightCtrlState, "");
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
             if (GUILayout.Button("Save configuration"))
             {
                 AdvancedFlyByWire.Instance.SaveState(null);


### PR DESCRIPTION
This resolves #39 and #40. To be honest, I'm not 100% sure why it resolves #39, since my testing indicated that setting state.pitchTrim had no effect, but trim now seems to work correctly for me in both override and non-override mode. See the individual commit messages and comments in code for more.