### PR TITLE
KSP 1.4 Linux compatibility

### DIFF
--- a/SDLController.cs
+++ b/SDLController.cs
@@ -85,7 +85,9 @@ namespace KSPAdvancedFlyByWire
             SDL.SDL_JoystickUpdate();
             SDL.SDL_Event ev;
             SDL.SDL_PollEvent(out ev);
+#if LINUX
             SDL.SDL_PushEvent(ref ev);
+#endif
         }
 
         public override string GetControllerName()

--- a/SDLController.cs
+++ b/SDLController.cs
@@ -85,6 +85,7 @@ namespace KSPAdvancedFlyByWire
             SDL.SDL_JoystickUpdate();
             SDL.SDL_Event ev;
             SDL.SDL_PollEvent(out ev);
+            SDL.SDL_PushEvent(ref ev);
         }
 
         public override string GetControllerName()

--- a/SDLController.cs
+++ b/SDLController.cs
@@ -83,11 +83,7 @@ namespace KSPAdvancedFlyByWire
         {
             InitializeSDL();
             SDL.SDL_JoystickUpdate();
-            SDL.SDL_Event ev;
-            SDL.SDL_PollEvent(out ev);
-#if LINUX
-            SDL.SDL_PushEvent(ref ev);
-#endif
+            SDL.SDL_PumpEvents();
         }
 
         public override string GetControllerName()


### PR DESCRIPTION
Recent Unity versions use SDL for input handling on Linux. That means, in order not to break KSP's input system, we mustn't consume any input inside the mod. As far as I understand the code I changed, its main purpose is to repopulate the event queue of SDL (as the event that gets polled is not used anywhere). The same effect can be achieved by pumping the event queue without reading from it.
That's what this pull request does.

This plugin is now interesting again, as KSP 1.4.1 has broken Joystick/Gamepad handling on Linux. It's currently impossible to assign input axis, but Advanced Fly-By-Wire just works.
Also, Toolbar Continued has been updated to 1.4.1, so Advanced Fly-By-Wire is just this patch and a recompile away from working on the new KSP.